### PR TITLE
Add metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/node_modules
+.DS_Store

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,25 @@
+This directory contains some scripts and data for generating metrics about the work of Open Web Docs.
+
+It's got three subdirectories: *query*, *data*, and *analyse*.
+
+## query
+
+This contains a script that will fetch all PRs from mdn/content and just log them as a huge JSON array. It takes a few minutes to run. You will need a [personal access token from GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to use this script.
+
+Then you pass the token in like this:
+
+```
+ node query-prs.js MY-TOKEN-HERE
+ ```
+
+ It's (obviously) advisable not to run this again and again, but to run it once, then analyse the results at your leisure.
+
+## data
+
+This contains data scraped from GitHub using the `query` script ("prs.json") and another data file called "organizations.json".
+
+The "organizations.json" file contains an object each of whose keys represents an organization. The key is the organization name. Each organization object lists the GitHub usernames for people in that organization for each month we are interested in.
+
+## analyse
+
+This contains a script that figures out, month by month, which PRs were files by members of a particular organization listed in "organizations.json".

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -16,10 +16,10 @@ Then you pass the token in like this:
 
 ## data
 
-This contains data scraped from GitHub using the `query` script ("prs.json") and another data file called "organizations.json".
+This contains a data file called "organizations.json".
 
 The "organizations.json" file contains an object each of whose keys represents an organization. The key is the organization name. Each organization object lists the GitHub usernames for people in that organization for each month we are interested in.
 
 ## analyse
 
-This contains a script that figures out, month by month, which PRs were files by members of a particular organization listed in "organizations.json".
+This contains a script that figures out, month by month, which PRs were files by members of a particular organization listed in "organizations.json". Note that it expects to see "prs.json" in "data", but that file is not checked into GitHub because it's too big. You'll need to get your own copy of that.

--- a/metrics/analyse/analyse-prs.js
+++ b/metrics/analyse/analyse-prs.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+
+function initializeBuckets(json) {
+
+  const buckets = {
+    '2021-01': [],
+    '2021-02': [],
+    '2021-03': [],
+    '2021-04': [],
+    '2021-05': [],
+    '2021-06': [],
+    '2021-07': [],
+    '2021-08': [],
+    '2021-09': [],
+    '2021-10': [],
+    '2021-11': [],
+    '2021-12': [],
+    '2022-01': [],
+    '2022-02': [],
+    '2022-03': []
+  }
+
+  for (const pr of json) {
+    const prefix = pr.created_at.slice(0, 7);
+    const bucket = buckets[prefix];
+    if (!bucket) continue;
+    const creatorIndex = bucket.findIndex(contributor => contributor.name === pr.user.login);
+    if (creatorIndex === -1) {
+      bucket.push({
+        name: pr.user.login,
+        count: 1
+      });
+    } else {
+      bucket[creatorIndex].count++;
+    }
+  }
+
+  return buckets;
+}
+
+function analyse(buckets, organization) {
+
+  for (const bucketName of Object.keys(buckets)) {
+    const team = organization[bucketName];
+    const users = buckets[bucketName].filter(user => team.includes(user.name));
+    const contributions = users.reduce((previousValue, currentValue) => previousValue + currentValue.count, 0)
+    console.log(`${bucketName}: ${contributions}`);
+  }
+
+}
+
+const prJSON = fs.readFileSync('../data/prs.json', 'utf8');
+const prs = JSON.parse(prJSON);
+
+const buckets = initializeBuckets(prs);
+
+const orgJSON = fs.readFileSync('../data/organizations.json', 'utf8');
+const organizations = JSON.parse(orgJSON);
+
+analyse(buckets, organizations['owd']);

--- a/metrics/data/organizations.json
+++ b/metrics/data/organizations.json
@@ -1,0 +1,19 @@
+{
+  "owd": {
+    "2021-01": ["Elchi3"],
+    "2021-02": ["Elchi3", "wbamberg"],
+    "2021-03": ["Elchi3", "wbamberg"],
+    "2021-04": ["Elchi3", "wbamberg"],
+    "2021-05": ["Elchi3", "wbamberg"],
+    "2021-06": ["Elchi3", "wbamberg", "teoli2003"],
+    "2021-07": ["Elchi3", "wbamberg", "teoli2003"],
+    "2021-08": ["Elchi3", "wbamberg", "teoli2003", "estelle"],
+    "2021-09": ["Elchi3", "wbamberg", "teoli2003", "estelle"],
+    "2021-10": ["Elchi3", "wbamberg", "teoli2003", "estelle"],
+    "2021-11": ["Elchi3", "wbamberg", "teoli2003", "estelle"],
+    "2021-12": ["Elchi3", "wbamberg", "teoli2003", "estelle"],
+    "2022-01": ["Elchi3", "wbamberg", "teoli2003", "estelle", "queengooborg"],
+    "2022-02": ["Elchi3", "wbamberg", "teoli2003", "estelle", "queengooborg"],
+    "2022-03": ["Elchi3", "wbamberg", "teoli2003", "estelle", "queengooborg"]
+  }
+}

--- a/metrics/query/package.json
+++ b/metrics/query/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "openwebdocs/metrics/query",
+  "version": "0.0.1",
+  "repository": "https://github.com/openwebdocs/scripts/",
+  "license": "MPL-2.0",
+  "author": "Open Web Docs",
+  "dependencies": {
+    "node-fetch": "^2.6.7"
+  }
+}

--- a/metrics/query/query-prs.js
+++ b/metrics/query/query-prs.js
@@ -1,0 +1,38 @@
+const fetch = require('node-fetch');
+
+const startURL = 'https://api.github.com/repos/mdn/content/pulls?state=all&per_page=100';
+
+function getNextURL(link) {
+  const bits = link.split(",").map(bit => bit.trim());
+  const next = bits.find( bit => bit.split(';')[1] === ' rel=\"next\"');
+  if (next) {
+    return next.split(';')[0].slice(1, -1);
+  }
+  return null;
+}
+
+let all = [];
+
+async function get(url, token) {
+
+  const requestHeaders = {
+    Authorization: `token ${token}`
+  };
+
+  const r = await fetch(url, {method:'GET', headers: requestHeaders});
+  const json = await r.json();
+  all = all.concat(json);
+
+  const link = r.headers.get("Link");
+  const next = getNextURL(link);
+  if (next) {
+    get(next, token);
+  } else {
+    console.log(JSON.stringify(all, null, '\t'));
+  }
+
+}
+
+const token = process.argv[2];
+
+get(startURL, token);


### PR DESCRIPTION
I would like us to get better at generating metrics for our activity. So I've filed this PR, that adds a couple of Node scripts.

The first one uses GitHub's API to fetch all PRs filed to mdn/content.

The second one uses that, and another file called "organizations.json", to work out, for each month, how many PRs were filed by members of a particular organization in each month. For example, it's currently hardcoded to use the "owd" org, so running it would give us:

```
2021-01: 15
2021-02: 12
2021-03: 17
2021-04: 32
2021-05: 49
2021-06: 167
2021-07: 168
2021-08: 168
2021-09: 163
2021-10: 119
2021-11: 80
2021-12: 51
2022-01: 51
2022-02: 98
2022-03: 122
```

...which is the number of PRs filed by OWD staff in each month. Obviously with different orgs we can compare.

I'm filing this here for a couple of reasons:
- I think it's important for us to be transparent about our metrics, and if we have errors in the code I want to know about them
- I'd be happy to get improvements from people who want to help improve them.

As you can see it's very rough at the moment (e.g. org being hardcoded to "owd"). But ready for feedback I think
(and usable now).