### PR TITLE
Improve shebang compatability and quote file paths

### DIFF
--- a/addRemoteOrigin.sh
+++ b/addRemoteOrigin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 clear
 echo "-------- Add remote origin for all directories --------------"
 
@@ -27,9 +27,9 @@ ORGANIZATION="mdn"
 for i in "${repositories[@]}"
 do
   echo "git remote add upstream https://github.com/${ORGANIZATION}/$i.git"
-  cd ${SYSTEM_DIR}/$i 
+  cd "${SYSTEM_DIR}/$i"
   git branch
-  git remote add upstream https://github.com/${ORGANIZATION}/$i.git
+  git remote add upstream "https://github.com/${ORGANIZATION}/$i.git"
 done
 
 

--- a/createDIRwithMD.sh
+++ b/createDIRwithMD.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # START ----------------------------
 #
@@ -26,7 +26,7 @@ goToCorrectDirectory () {
 
   path="${SYSTEM_DIR}${REPO_PATH}${sub_path}"
 
-  cd ${path}
+  cd "${path}"
   echo "Selected Directory:"
   pwd
   echo "Is that correct? (y/n/x for exit)"
@@ -50,9 +50,9 @@ createDocuments () {
     echo "Sorry, that folder already exists. Try again."
     createDocuments
   else
-    mkdir ${newFileName}
+    mkdir "${newFileName}"
     # create an index.md in that folder
-    touch ${newFileName}/index.md
+    touch "${newFileName}/index.md"
     addContent  
   fi
 # Ask user to enter a new folder name or exit?
@@ -82,7 +82,7 @@ addContent () {
   export usefulFileName=${newFileName//_/ }
   export sectionTitle=(${words[${length}-2]//_// })
 
-  cat > ${newFileName}/index.md <<- EOM
+  cat > "${newFileName}/index.md" <<- EOM
 ---
 title: '${sectionTitle}: ${usefulFileName}'
 slug: Web${sub_path}/${newFileName}

--- a/pushCurrentAndBase.sh
+++ b/pushCurrentAndBase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
  
 # run after fetching upstream
 # ~/scripts/startFresh.sh

--- a/startFresh.sh
+++ b/startFresh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 clear
 echo "-------- Update all repos! --------------"
 
@@ -25,7 +25,7 @@ path=''
 for i in "${repositories[@]}"
   do
     path="${SYSTEM_DIR}/$i"
-    cd ${path}
+    cd "${path}"
 
     #content has different origing
     if [[ i == content ]]

--- a/upstreamAllRepos.sh
+++ b/upstreamAllRepos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 clear
 echo "-------- Update all repos! --------------"
 
@@ -34,7 +34,7 @@ path=''
 for i in "${repositories[@]}"
   do
     path="${SYSTEM_DIR}/$i"
-    cd ${path}
+    cd "${path}"
 
     #check if the repo has a default 'main branch'
     if [[ ${mainBranch[*]} =~ $i ]]


### PR DESCRIPTION
This makes a few improvements:

- Use `#!/usr/bin/env bash` as shebang since the `#!/bin/bash` doesn't work on NixOS and some BSDs
- Quote variables that could definitely contain whitespace (variables representing file and directory paths)